### PR TITLE
Update deps

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -43,7 +43,7 @@ cffi==1.15.1
     # via
     #   -c requirements/requirements.txt
     #   argon2-cffi-bindings
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   -c requirements/requirements.txt
     #   requests
@@ -126,7 +126,7 @@ jinja2==3.1.2
     #   nbsphinx
     #   notebook
     #   sphinx
-jsonschema==4.12.1
+jsonschema==4.14.0
     # via
     #   -c requirements/requirements.txt
     #   nbformat

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -26,7 +26,7 @@ certifi==2022.6.15
     # via requests
 cffi==1.15.1
     # via argon2-cffi-bindings
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via requests
 colorcet==3.0.0
     # via holoviews
@@ -83,7 +83,7 @@ jinja2==3.1.2
     #   bokeh
     #   nbconvert
     #   notebook
-jsonschema==4.12.1
+jsonschema==4.14.0
     # via nbformat
 jupyter-client==7.3.4
     # via
@@ -98,7 +98,7 @@ jupyter-core==4.11.1
     #   notebook
 jupyterlab-pygments==0.2.2
     # via nbconvert
-jupyterlab-widgets==3.0.1
+jupyterlab-widgets==3.0.2
     # via ipywidgets
 kiwisolver==1.4.4
     # via matplotlib
@@ -305,7 +305,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-widgetsnbextension==4.0.1
+widgetsnbextension==4.0.2
     # via ipywidgets
 zipp==3.8.1
     # via


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.